### PR TITLE
Fix minimum iOS version in `README.md`

### DIFF
--- a/jitsi_meet_wrapper/README.md
+++ b/jitsi_meet_wrapper/README.md
@@ -49,7 +49,7 @@ It is recommended to take a look at them, if you have any issues or need more de
 
 #### Podfile
 
-The platform (and also the deployment target) needs to be set to `11.0` or newer and bitcode needs to be disabled.<br>
+The platform (and also the deployment target) needs to be set to `12.0` or newer and bitcode needs to be disabled.<br>
 The file should look similar to below:
 
 ```


### PR DESCRIPTION
The Jitsi iOS SDK requires iOS +12.0. The code snippet for the `Podfile` already uses the correct iOS version. But the text above the code snippet uses 11.0 as minimum iOS version. I think it should be 12.0, right?