### PR TITLE
Add a note to the `README.md` how to compile your Android app for a lower SDK version

### DIFF
--- a/jitsi_meet_wrapper/README.md
+++ b/jitsi_meet_wrapper/README.md
@@ -170,7 +170,10 @@ If you still want to compile your app for a SDK version lower than 23, you can a
 
     <application tools:replace="android:label"
 ```
-But keep in mind that when you call methods of this package with an unsupported SDK version, your app could crash. So you should check the SDK version of the device before calling any Jitsi methods. If a user has an unsupported SDK version, you could show a dialog that the Jitsi feature is not support for this device. This has the advantage that these users can still use other features of the app which don't require that minimum SDK version.
+
+We will try to keep this list of overridden libraries up-to-date. In case it does not work, please feel free to create an issue or see [this](https://github.com/saibotma/jitsi_meet_wrapper/pull/32#discussion_r867651938) comment for how to generate an updated list of overridden libraries.
+
+Keep in mind that when you call methods of this package with an unsupported SDK version, your app could crash. So you should check the SDK version of the device before calling any Jitsi methods. If a user has an unsupported SDK version, you could show a dialog that the Jitsi feature is not support for this device. This has the advantage that these users can still use other features of the app which don't require that minimum SDK version.
 
 #### ProGuard
 

--- a/jitsi_meet_wrapper/README.md
+++ b/jitsi_meet_wrapper/README.md
@@ -165,7 +165,7 @@ If you still want to compile your app for a SDK version lower than 23, you can a
           xmlns:tools="http://schemas.android.com/tools"
           package="dev.saibotma.jitsi_meet_wrapper_example">
 
-    <!-- Add this the following line -->
+    <!-- Add this -->
     <uses-sdk tools:overrideLibrary="dev.saibotma.jitsi_meet_wrapper, org.jitsi.meet.sdk, co.apptailor.googlesignin, com.calendarevents, com.reactnativecommunity.asyncstorage, com.reactnativecommunity.netinfo, com.rnimmersive, com.corbt.keepawake, com.BV.LinearGradient, com.horcrux.svg, com.oney.WebRTCModule, com.ocetnik.timer, com.kevinresol.react_native_default_preference, com.learnium.RNDeviceInfo, com.amplitude.reactnative, com.reactnativegooglesignin, com.reactnativecommunity.clipboard, com.swmansion.gesturehandler.react, org.linusu, org.reactnative.maskedview, com.reactnativepagerview, com.oblador.performance, com.swmansion.reanimated, com.th3rdwave.safeareacontext, com.swmansion.rnscreens, com.reactnativecommunity.slider, org.devio.rn.splashscreen, com.brentvatne.react, com.reactnativecommunity.webview"/>
 
     <application tools:replace="android:label"

--- a/jitsi_meet_wrapper/README.md
+++ b/jitsi_meet_wrapper/README.md
@@ -170,7 +170,7 @@ If you still want to compile your app for a SDK version lower than 23, you can a
 
     <application tools:replace="android:label"
 ```
-But keep in mind you when you call methods of this package with an unsupported SDK version, your app could crash. So you could check the SDK version of the device before calling any Jitsi methods. If a user has an unsupported SDK version, you could show a dialog that the Jitsi feature is not support for this device. This has the advantage that these users can still use other features of the app which don't require that minimum SDK version.
+But keep in mind that when you call methods of this package with an unsupported SDK version, your app could crash. So you should check the SDK version of the device before calling any Jitsi methods. If a user has an unsupported SDK version, you could show a dialog that the Jitsi feature is not support for this device. This has the advantage that these users can still use other features of the app which don't require that minimum SDK version.
 
 #### ProGuard
 

--- a/jitsi_meet_wrapper/README.md
+++ b/jitsi_meet_wrapper/README.md
@@ -159,6 +159,19 @@ android {
 }
 ```
 
+If you still want to compile your app for a SDK version lower than 23, you can add the following line to your `AndroidManifest.xml`:
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          package="dev.saibotma.jitsi_meet_wrapper_example">
+
+    <!-- Add this the following line -->
+    <uses-sdk tools:overrideLibrary="dev.saibotma.jitsi_meet_wrapper, org.jitsi.meet.sdk, co.apptailor.googlesignin, com.calendarevents, com.reactnativecommunity.asyncstorage, com.reactnativecommunity.netinfo, com.rnimmersive, com.corbt.keepawake, com.BV.LinearGradient, com.horcrux.svg, com.oney.WebRTCModule, com.ocetnik.timer, com.kevinresol.react_native_default_preference, com.learnium.RNDeviceInfo, com.amplitude.reactnative, com.reactnativegooglesignin, com.reactnativecommunity.clipboard, com.swmansion.gesturehandler.react, org.linusu, org.reactnative.maskedview, com.reactnativepagerview, com.oblador.performance, com.swmansion.reanimated, com.th3rdwave.safeareacontext, com.swmansion.rnscreens, com.reactnativecommunity.slider, org.devio.rn.splashscreen, com.brentvatne.react, com.reactnativecommunity.webview"/>
+
+    <application tools:replace="android:label"
+```
+But keep in mind you when you call methods of this package with an unsupported SDK version, your app could crash. So you could check the SDK version of the device before calling any Jitsi methods. If a user has an unsupported SDK version, you could show a dialog that the Jitsi feature is not support for this device. This has the advantage that these users can still use other features of the app which don't require that minimum SDK version.
+
 #### ProGuard
 
 You might have to add some ProGuard rules if your app crashes when using this package. Follow the


### PR DESCRIPTION
A proposal for better documentation: There might the case where videoconferences are just one of many features in your app. In this case it could be bad, if you need to increase the minium SDK version for all users, even when only a small set of users are using the videoconference feature.