### PR TITLE
setMuted and closeMeeting methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,4 +367,6 @@ hs_err_pid*
 
 !/gradle/wrapper/gradle-wrapper.jar
 
+jitsi_meet_wrapper/.idea/
+jitsi_meet_wrapper_platform_interface/.idea/
 # End of https://www.toptal.com/developers/gitignore/api/intellij,androidstudio,xcode,flutter,gradle,cocoapods

--- a/jitsi_meet_wrapper/README.md
+++ b/jitsi_meet_wrapper/README.md
@@ -22,13 +22,26 @@ Nevertheless, please always create an issue and I will try to have a look.
 
 <a name="join-a-meeting"></a>
 
-## Join a meeting
+### Join a meeting
 
 To join a meeting, you have to create meeting options and then launch the meeting:
 
 ```dart
 var options = JitsiMeetingOptions(roomName: "my-room");
 await JitsiMeetWrapper.joinMeeting(options);
+```
+
+
+### Mute or unmute
+
+```dart
+JitsiMeetWrapper.setMuted(true);
+```
+
+### Close the meeting:
+
+```dart
+JitsiMeetWrapper.closeMeeting();
 ```
 
 Take a look
@@ -180,7 +193,7 @@ To listen to meeting events per meeting, pass in a `JitsiMeetingListener`
 to `joinMeeting`. The listener will automatically be removed when the conference is over
 (which is not `onConferenceTerminated`).
 
-```
+```dart
 await JitsiMeetWrapper.joinMeeting(
   options: options,
   listener: JitsiMeetingListener(

--- a/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperActivity.kt
+++ b/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperActivity.kt
@@ -8,6 +8,7 @@ import android.content.IntentFilter
 import android.os.Bundle
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import org.jitsi.meet.sdk.BroadcastEvent
+import org.jitsi.meet.sdk.BroadcastIntentHelper;
 import org.jitsi.meet.sdk.JitsiMeetActivity
 import org.jitsi.meet.sdk.JitsiMeetConferenceOptions
 import java.util.HashMap
@@ -73,5 +74,9 @@ class JitsiMeetWrapperActivity : JitsiMeetActivity() {
         super.onDestroy()
         LocalBroadcastManager.getInstance(this).unregisterReceiver(this.broadcastReceiver)
         eventStreamHandler.onClosed()
+    }
+    fun setMuted(muted: Boolean) {
+        val muteBroadcastIntent: Intent = BroadcastIntentHelper.buildSetAudioMutedIntent(muted)
+        LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(muteBroadcastIntent)
     }
 }

--- a/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperActivity.kt
+++ b/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperActivity.kt
@@ -75,8 +75,4 @@ class JitsiMeetWrapperActivity : JitsiMeetActivity() {
         LocalBroadcastManager.getInstance(this).unregisterReceiver(this.broadcastReceiver)
         eventStreamHandler.onClosed()
     }
-    fun setMuted(muted: Boolean) {
-        val muteBroadcastIntent: Intent = BroadcastIntentHelper.buildSetAudioMutedIntent(muted)
-        LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(muteBroadcastIntent)
-    }
 }

--- a/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperPlugin.kt
+++ b/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperPlugin.kt
@@ -38,6 +38,8 @@ class JitsiMeetWrapperPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         when (call.method) {
             "joinMeeting" -> joinMeeting(call, result)
+            "setMuted" -> setMuted(call, result)
+            "closeMeeting" -> closeMeeting(call, result)
             else -> result.notImplemented()
         }
     }
@@ -114,6 +116,21 @@ class JitsiMeetWrapperPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
         JitsiMeetWrapperActivity.launch(activity!!, options)
         result.success("Successfully joined room: $room")
+    }
+    private fun setMuted(call: MethodCall, result: Result) {
+        val muted = call.argument<Boolean>("muted") ?: false
+
+        val muteBroadcastIntent: Intent = BroadcastIntentHelper.buildSetAudioMutedIntent(muted)
+        LocalBroadcastManager.getInstance(activity!!.applicationContext).sendBroadcast(muteBroadcastIntent)
+
+        result.success("Successfully muted: $muted")
+    }
+
+    private fun closeMeeting(call: MethodCall, result: Result) {
+        val hangupIntent: Intent = BroadcastIntentHelper.buildHangUpIntent()
+        LocalBroadcastManager.getInstance(activity!!.applicationContext).sendBroadcast(hangupIntent)
+
+        result.success("Successfully closed meeting")
     }
 
     override fun onDetachedFromActivity() {

--- a/jitsi_meet_wrapper/ios/Classes/JitsiMeetWrapperViewController.swift
+++ b/jitsi_meet_wrapper/ios/Classes/JitsiMeetWrapperViewController.swift
@@ -9,6 +9,7 @@ class JitsiMeetWrapperViewController: UIViewController {
 
     let options: JitsiMeetConferenceOptions
     let eventSink: FlutterEventSink
+    var sourceJitsiMeetView: JitsiMeetView?
 
     // https://stackoverflow.com/a/55208383/6172447
     init(options: JitsiMeetConferenceOptions, eventSink: @escaping FlutterEventSink) {
@@ -33,21 +34,21 @@ class JitsiMeetWrapperViewController: UIViewController {
     func openJitsiMeet() {
         cleanUp()
 
-        let sourceJitsiMeetView = JitsiMeetView()
+        sourceJitsiMeetView = JitsiMeetView()
         // Need to wrap the jitsi view in another view that absorbs all the pointer events
         // because of a flutter bug: https://github.com/flutter/flutter/issues/14720
         let jitsiMeetView = AbsorbPointersView()
         jitsiMeetView.backgroundColor = .black
         self.jitsiMeetView = jitsiMeetView
 
-        jitsiMeetView.addSubview(sourceJitsiMeetView)
+        jitsiMeetView.addSubview(sourceJitsiMeetView!)
 
         // Make the jitsi view redraw when orientation changes.
         // From: https://stackoverflow.com/a/45860445/6172447
-        sourceJitsiMeetView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        sourceJitsiMeetView!.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
-        sourceJitsiMeetView.delegate = self
-        sourceJitsiMeetView.join(options)
+        sourceJitsiMeetView!.delegate = self
+        sourceJitsiMeetView!.join(options)
 
         // Pip only works inside the app and not OS wide at the moment:
         // https://github.com/jitsi/jitsi-meet/issues/3515#issuecomment-427846699

--- a/jitsi_meet_wrapper/ios/Classes/SwiftJitsiMeetWrapperPlugin.swift
+++ b/jitsi_meet_wrapper/ios/Classes/SwiftJitsiMeetWrapperPlugin.swift
@@ -26,6 +26,12 @@ public class SwiftJitsiMeetWrapperPlugin: NSObject, FlutterPlugin, FlutterStream
         if (call.method == "joinMeeting") {
             joinMeeting(call, result: result)
             return
+        } else if (call.method == "setMuted") {
+            setMuted(call, result: result)
+            return
+        } else if (call.method == "closeMeeting") {
+            closeMeeting(call, result: result)
+            return
         }
     }
 
@@ -97,6 +103,18 @@ public class SwiftJitsiMeetWrapperPlugin: NSObject, FlutterPlugin, FlutterStream
         // In order to make pip mode work.
         jitsiViewController!.modalPresentationStyle = .overFullScreen
         flutterViewController.present(jitsiViewController!, animated: true)
+        result(nil)
+    }
+    
+    private func setMuted(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let arguments = call.arguments as! [String: Any]
+        let muted = arguments["muted"] as? Bool ?? false
+        jitsiViewController?.sourceJitsiMeetView?.setAudioMuted(muted)
+        result(nil)
+    }
+    
+    private func closeMeeting(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        jitsiViewController?.sourceJitsiMeetView?.hangUp()
         result(nil)
     }
 

--- a/jitsi_meet_wrapper/lib/jitsi_meet_wrapper.dart
+++ b/jitsi_meet_wrapper/lib/jitsi_meet_wrapper.dart
@@ -27,4 +27,14 @@ class JitsiMeetWrapper {
     return await JitsiMeetWrapperPlatformInterface.instance
         .joinMeeting(options: options, listener: listener);
   }
+
+  static Future<JitsiMeetingResponse> setMuted(bool muted) async {
+    return await JitsiMeetWrapperPlatformInterface.instance.setMuted(
+      muted: muted,
+    );
+  }
+
+  static Future<JitsiMeetingResponse> closeMeeting() async {
+    return await JitsiMeetWrapperPlatformInterface.instance.closeMeeting();
+  }
 }

--- a/jitsi_meet_wrapper/pubspec.yaml
+++ b/jitsi_meet_wrapper/pubspec.yaml
@@ -11,7 +11,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  jitsi_meet_wrapper_platform_interface: ^0.0.3
+  # jitsi_meet_wrapper_platform_interface: ^0.0.3
+  jitsi_meet_wrapper_platform_interface:
+    path: ../jitsi_meet_wrapper_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/jitsi_meet_wrapper_platform_interface/lib/jitsi_meet_wrapper_platform_interface.dart
+++ b/jitsi_meet_wrapper_platform_interface/lib/jitsi_meet_wrapper_platform_interface.dart
@@ -6,16 +6,17 @@ import 'jitsi_meeting_options.dart';
 import 'jitsi_meeting_response.dart';
 
 export 'feature_flag.dart';
+export 'jitsi_meeting_listener.dart';
 export 'jitsi_meeting_options.dart';
 export 'jitsi_meeting_response.dart';
-export 'jitsi_meeting_listener.dart';
 
 abstract class JitsiMeetWrapperPlatformInterface extends PlatformInterface {
   JitsiMeetWrapperPlatformInterface() : super(token: _token);
 
   static final Object _token = Object();
 
-  static JitsiMeetWrapperPlatformInterface _instance = MethodChannelJitsiMeetWrapper();
+  static JitsiMeetWrapperPlatformInterface _instance =
+      MethodChannelJitsiMeetWrapper();
 
   /// The default instance of [JitsiMeetWrapperPlatformInterface] to use.
   ///
@@ -33,5 +34,13 @@ abstract class JitsiMeetWrapperPlatformInterface extends PlatformInterface {
     JitsiMeetingListener? listener,
   }) async {
     throw UnimplementedError('joinMeeting has not been implemented.');
+  }
+
+  Future<JitsiMeetingResponse> setMuted({required bool muted}) async {
+    throw UnimplementedError('setMuted has not been implemented.');
+  }
+
+  Future<JitsiMeetingResponse> closeMeeting() async {
+    throw UnimplementedError('closeMeeting has not been implemented.');
   }
 }

--- a/jitsi_meet_wrapper_platform_interface/lib/method_channel_jitsi_meet_wrapper.dart
+++ b/jitsi_meet_wrapper_platform_interface/lib/method_channel_jitsi_meet_wrapper.dart
@@ -44,7 +44,27 @@ class MethodChannelJitsiMeetWrapper extends JitsiMeetWrapperPlatformInterface {
       return JitsiMeetingResponse(isSuccess: true, message: message);
     }).catchError((error) {
       return JitsiMeetingResponse(
-        isSuccess: true,
+        isSuccess: false,
+        message: error.toString(),
+        error: error,
+      );
+    });
+  }
+
+  @override
+  Future<JitsiMeetingResponse> setMuted({
+    required bool muted,
+  }) async {
+    Map<String, dynamic> _options = {
+      'muted': muted,
+    };
+    return await _methodChannel
+        .invokeMethod<String>('setMuted', _options)
+        .then((message) {
+      return JitsiMeetingResponse(isSuccess: true, message: message);
+    }).catchError((error) {
+      return JitsiMeetingResponse(
+        isSuccess: false,
         message: error.toString(),
         error: error,
       );
@@ -206,6 +226,21 @@ class MethodChannelJitsiMeetWrapper extends JitsiMeetWrapperPlatformInterface {
       case FeatureFlag.isVideoShareButtonEnabled:
         return 'video-share.enabled';
     }
+  }
+
+  @override
+  Future<JitsiMeetingResponse> closeMeeting() async {
+    return await _methodChannel
+        .invokeMethod<String>('closeMeeting')
+        .then((message) {
+      return JitsiMeetingResponse(isSuccess: true, message: message);
+    }).catchError((error) {
+      return JitsiMeetingResponse(
+        isSuccess: false,
+        message: error.toString(),
+        error: error,
+      );
+    });
   }
 }
 


### PR DESCRIPTION
Added implementations of `setMuted` and `closeMeeting` for Android and iOS.

### Mute or unmute

```dart
JitsiMeetWrapper.setMuted(true);
```

### Close the meeting:

```dart
JitsiMeetWrapper.closeMeeting();
```

Tested and working 🚀 

I had to modify the `jitsi_meet_wrapper_platform_interface` dependency to include the new methods.
Please modify this `yml` after publishing a new version of the platform interface.

```yml
dependencies:
  flutter:
    sdk: flutter
  # jitsi_meet_wrapper_platform_interface: ^0.0.3
  jitsi_meet_wrapper_platform_interface:
    path: ../jitsi_meet_wrapper_platform_interface
```