### PR TITLE
Embed Jitsi as a PlatformView

### DIFF
--- a/jitsi_meet_wrapper/example/lib/jitsi_meet_view.dart
+++ b/jitsi_meet_wrapper/example/lib/jitsi_meet_view.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:jitsi_meet_wrapper/jitsi_meet_wrapper.dart';
+
+class JitsiMeetView extends StatefulWidget {
+  const JitsiMeetView({
+    Key? key,
+    required this.options,
+    required this.listener,
+  }) : super(key: key);
+
+  final JitsiMeetingOptions options;
+  final JitsiMeetingListener listener;
+
+  @override
+  State<JitsiMeetView> createState() => _JitsiMeetViewState();
+}
+
+class _JitsiMeetViewState extends State<JitsiMeetView> {
+  JitsiMeetViewController? _controller;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Jitsi meet widget'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                _controller?.join();
+              },
+              child: const Text('Join'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                _controller?.hangUp();
+              },
+              child: const Text('hangup'),
+            ),
+            SizedBox(
+              height: 500,
+              width: 400,
+              child: JitsiMeetNativeView(
+                options: widget.options,
+                onViewCreated: (controller) {
+                  _controller = controller;
+                  _controller?.attachListener(widget.listener);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/jitsi_meet_wrapper/ios/Classes/JitsiNativeView.swift
+++ b/jitsi_meet_wrapper/ios/Classes/JitsiNativeView.swift
@@ -1,0 +1,186 @@
+import Flutter
+import UIKit
+import JitsiMeetSDK
+
+class JitsiViewFactory: NSObject, FlutterPlatformViewFactory {
+    
+    private var messenger: FlutterBinaryMessenger
+    
+    init(messenger:FlutterBinaryMessenger){
+        
+        self.messenger = messenger
+        super.init()
+    }
+    
+    public func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+        return FlutterStandardMessageCodec.sharedInstance()
+    }
+    
+    func create(
+        withFrame frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?
+    ) -> FlutterPlatformView {
+        return JitsiView(frame: frame, viewId: viewId, args: args, binaryMessenger: messenger)
+    }
+}
+
+class JitsiView: NSObject, FlutterPlatformView {
+    private var _jitsiMeetView: JitsiMeetView
+    private var _options: JitsiMeetConferenceOptions
+    private var _methodChannel: FlutterMethodChannel
+    
+    let frame: CGRect
+    let viewId: Int64
+    var eventSink : FlutterEventSink?
+    var passArgs : Any?
+    
+    init(
+        frame: CGRect,
+        viewId: Int64,
+        args: Any?,
+        binaryMessenger messenger: FlutterBinaryMessenger?
+    ) {
+        _options = JitsiMeetConferenceOptions.fromBuilder { (builder) in
+            if let jitsiOptions = args as? [String:Any]   {
+                
+                // set options which is received from flutter
+                let isAudioOnly = jitsiOptions["isAudioOnly"] as? Bool
+                let isAudioMuted = jitsiOptions["isAudioMuted"] as? Bool
+                let isVideoMuted = jitsiOptions["isVideoMuted"] as? Bool
+                let roomNameOrUrl = jitsiOptions["roomNameOrUrl"] as? String
+                let serverUrl = jitsiOptions["serverUrl"] as? String
+                let subject = jitsiOptions["subject"] as? String
+                let userDisplayName = jitsiOptions["userDisplayName"] as? String
+                let userEmail = jitsiOptions["userEmail"] as? String
+
+                let token = jitsiOptions["token"] as? String
+                
+                // UserInfo Update param from flutter
+                let userInfo = JitsiMeetUserInfo()
+                userInfo.displayName = userDisplayName
+                userInfo.email = userEmail
+                
+                builder.room = roomNameOrUrl
+                builder.setAudioOnly(isAudioOnly ?? true)
+                builder.setAudioMuted(isAudioMuted ?? true)
+                builder.setVideoMuted(isVideoMuted ?? true)
+                if(subject?.isEmpty == false) {
+                    builder.setSubject(subject!)
+                }
+                if(token?.isEmpty == false) {
+                    builder.token =  token
+                }
+                builder.serverURL = URL.init(string: serverUrl ?? "https://meet.jit.si")
+                builder.userInfo = userInfo
+                builder.setFeatureFlag("prejoinpage.enabled", withBoolean: false)
+                
+                
+                if let featureFlag = jitsiOptions["featureFlags"] as? [String:Any] {
+                    for (key, value) in featureFlag {
+                        builder.setFeatureFlag(key, withValue: value)
+                    }
+                }
+            }
+        }
+        
+        _jitsiMeetView = JitsiMeetView()
+        _methodChannel = FlutterMethodChannel(name: "plugins.jitsi_meet_wrapper/jitsi_meet_native_view_\(viewId)", binaryMessenger: messenger!)
+
+        self.frame = frame
+        self.viewId = viewId
+        self.passArgs = args
+        
+        super.init()
+        _methodChannel.setMethodCallHandler(onMethodCall)
+    }
+    
+    func view() -> UIView {
+        _jitsiMeetView.delegate = self
+        EventManager.shared.eventSink?(["event": "opened"])
+        return _jitsiMeetView
+    }
+
+    
+    func onMethodCall(call: FlutterMethodCall, result: FlutterResult) {
+        switch(call.method){
+           case "join":
+             join( call, result: result)
+            
+           case "hangUp":
+                hangUp( call, result: result)
+            
+           case "setAudioMuted":
+                setAudioMuted(call, result: result)
+           default:
+               result(FlutterMethodNotImplemented)
+           }
+       }
+    
+    private func join(_ call: FlutterMethodCall, result: FlutterResult){
+        _jitsiMeetView.join(_options)
+        result(nil)
+
+    }
+    
+    private func hangUp(_ call: FlutterMethodCall, result: FlutterResult){
+       _jitsiMeetView.hangUp()
+       result(nil)
+
+   }
+    
+    private func setAudioMuted(_ call: FlutterMethodCall, result: FlutterResult) {
+        let arguments = call.arguments as! [String: Any]
+        let isMuted = arguments["isMuted"] as? Bool ?? false
+        _jitsiMeetView.setAudioMuted(isMuted)
+        result(nil)
+    }
+    
+}
+
+
+extension JitsiView: JitsiMeetViewDelegate {
+    func conferenceJoined(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "conferenceJoined", "data": data])
+    }
+    
+    func conferenceTerminated(_ data: [AnyHashable: Any]) {
+        EventManager.shared.eventSink?(["event": "conferenceTerminated", "data": data])
+    }
+    
+    func conferenceWillJoin(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "conferenceWillJoin", "data": data])
+    }
+
+    func participantJoined(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "participantJoined", "data": data])
+    }
+    
+    func participantLeft(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "participantLeft", "data": data])
+    }
+    
+    func audioMutedChanged(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "audioMutedChanged", "data": data])
+    }
+    
+    func endpointTextMessageReceived(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "endpointTextMessageReceived", "data": data])
+    }
+    
+    func screenShareToggled(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "screenShareToggled", "data": data])
+    }
+    
+    func chatMessageReceived(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "chatMessageReceived", "data": data])
+    }
+    
+    func chatToggled(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "chatToggled", "data": data])
+    }
+    
+    func videoMutedChanged(_ data: [AnyHashable : Any]) {
+        EventManager.shared.eventSink?(["event": "videoMutedChanged", "data": data])
+    }
+}

--- a/jitsi_meet_wrapper/ios/Classes/SwiftJitsiMeetWrapperPlugin.swift
+++ b/jitsi_meet_wrapper/ios/Classes/SwiftJitsiMeetWrapperPlugin.swift
@@ -12,6 +12,8 @@ public class SwiftJitsiMeetWrapperPlugin: NSObject, FlutterPlugin, FlutterStream
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
+        let factory = JitsiViewFactory(messenger: registrar.messenger())
+        registrar.register(factory, withId: "plugins.jitsi_meet_wrapper:jitsi_meet_native_view")
         let channel = FlutterMethodChannel(name: "jitsi_meet_wrapper", binaryMessenger: registrar.messenger())
         let flutterViewController: UIViewController = (UIApplication.shared.delegate?.window??.rootViewController)!
         let instance = SwiftJitsiMeetWrapperPlugin(flutterViewController: flutterViewController)
@@ -122,10 +124,18 @@ public class SwiftJitsiMeetWrapperPlugin: NSObject, FlutterPlugin, FlutterStream
 
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         eventSink = events
+        EventManager.shared.eventSink = eventSink
         return nil
     }
 
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        EventManager.shared.eventSink = eventSink
         return nil
     }
+}
+
+class EventManager{
+    static let shared = EventManager()
+    var eventSink : FlutterEventSink?
+    init(){}
 }

--- a/jitsi_meet_wrapper/lib/jitsi_meet_native_view/jitsi_meet_native_view.dart
+++ b/jitsi_meet_wrapper/lib/jitsi_meet_native_view/jitsi_meet_native_view.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+import 'jitsi_meet_native_view_controller.dart';
+import 'package:jitsi_meet_wrapper_platform_interface/jitsi_meeting_listener.dart';
+import 'package:jitsi_meet_wrapper_platform_interface/jitsi_meeting_options.dart';
+
+typedef JItsiMeetNativeViewCreatedCallback = void Function(
+    JitsiMeetViewController controller);
+
+class JitsiMeetNativeView extends StatelessWidget {
+  const JitsiMeetNativeView({
+    Key? key,
+    required this.onViewCreated,
+    required this.options,
+  }) : super(key: key);
+
+  final JItsiMeetNativeViewCreatedCallback onViewCreated;
+  final JitsiMeetingOptions options;
+
+  @override
+  Widget build(BuildContext context) {
+    const String viewType = 'plugins.jitsi_meet_wrapper:jitsi_meet_native_view';
+
+    return UiKitView(
+      viewType: viewType,
+      creationParams: options.toMap(),
+      layoutDirection: TextDirection.ltr,
+      creationParamsCodec: const StandardMessageCodec(),
+      onPlatformViewCreated: _onPlatformViewCreated,
+    );
+  }
+
+  void _onPlatformViewCreated(int id) => onViewCreated(
+        JitsiMeetViewController(
+          id: id,
+        ),
+      );
+}

--- a/jitsi_meet_wrapper/lib/jitsi_meet_native_view/jitsi_meet_native_view_controller.dart
+++ b/jitsi_meet_wrapper/lib/jitsi_meet_native_view/jitsi_meet_native_view_controller.dart
@@ -1,0 +1,34 @@
+// WebView Controller class to set url etc
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:jitsi_meet_wrapper_platform_interface/jitsi_meet_wrapper_platform_interface.dart';
+
+class JitsiMeetViewController {
+  JitsiMeetViewController({
+    required int id,
+    JitsiMeetingListener? listener,
+  })  : _channel =
+            MethodChannel('plugins.jitsi_meet_wrapper/jitsi_meet_native_view_$id'),
+        _listener = listener;
+
+  final MethodChannel _channel;
+  final EventChannel _eventChannel =
+      const EventChannel('plugins.jitsi_meet_wrapper:jitsi_meet_native_view');
+  JitsiMeetingListener? _listener;
+
+  Future<void> join() async {
+    await _channel.invokeMethod('join');
+  }
+
+  Future<void> hangUp() async {
+    await _channel.invokeMethod('hangUp');
+  }
+
+  Future<void> setAudioMuted(bool isMuted) async {
+    await _channel.invokeMethod('setAudioMuted', {"isMuted": isMuted});
+  }
+
+  Future<void> attachListener(JitsiMeetingListener listener) async {
+    await JitsiMeetWrapperPlatformInterface.instance.attachListener(listener);
+  }
+}

--- a/jitsi_meet_wrapper/lib/jitsi_meet_wrapper.dart
+++ b/jitsi_meet_wrapper/lib/jitsi_meet_wrapper.dart
@@ -9,6 +9,9 @@ export 'package:jitsi_meet_wrapper_platform_interface/jitsi_meet_wrapper_platfor
         FeatureFlag,
         JitsiMeetingListener;
 
+export 'jitsi_meet_native_view/jitsi_meet_native_view.dart';
+export 'jitsi_meet_native_view/jitsi_meet_native_view_controller.dart';
+
 class JitsiMeetWrapper {
   /// Joins a meeting based on the JitsiMeetingOptions passed in.
   /// A JitsiMeetingListener can be attached to this meeting that will automatically

--- a/jitsi_meet_wrapper/pubspec.yaml
+++ b/jitsi_meet_wrapper/pubspec.yaml
@@ -11,7 +11,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  jitsi_meet_wrapper_platform_interface: ^0.0.4
+  # jitsi_meet_wrapper_platform_interface: ^0.0.4
+  jitsi_meet_wrapper_platform_interface:
+    # To be replaced with newer version of jitsi_meet_wrapper_platform_interface released
+    path: ../jitsi_meet_wrapper_platform_interface
 
 
 dev_dependencies:

--- a/jitsi_meet_wrapper_platform_interface/lib/feature_flag.dart
+++ b/jitsi_meet_wrapper_platform_interface/lib/feature_flag.dart
@@ -156,4 +156,8 @@ enum FeatureFlag {
   /// Flag indicating if the welcome page should be enabled.
   /// Default: disabled (false).
   isWelcomePageEnabled,
+
+  /// Flag indicating if the prejoin page should be enabled.
+  /// Default: enabled (true).
+  isPrejoinPageEnabled,
 }

--- a/jitsi_meet_wrapper_platform_interface/lib/jitsi_meet_wrapper_platform_interface.dart
+++ b/jitsi_meet_wrapper_platform_interface/lib/jitsi_meet_wrapper_platform_interface.dart
@@ -42,4 +42,10 @@ abstract class JitsiMeetWrapperPlatformInterface extends PlatformInterface {
   Future<JitsiMeetingResponse> hangUp() async {
     throw UnimplementedError('hangUp has not been implemented.');
   }
+
+  Future<void> attachListener(
+    JitsiMeetingListener listener,
+    ) async {
+    throw UnimplementedError('hangUp has not been implemented.');
+  }
 }

--- a/jitsi_meet_wrapper_platform_interface/lib/jitsi_meeting_options.dart
+++ b/jitsi_meet_wrapper_platform_interface/lib/jitsi_meeting_options.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'dart:convert';
+
 import 'package:collection/collection.dart';
 
 import 'feature_flag.dart';
@@ -30,7 +33,6 @@ class JitsiMeetingOptions {
     this.featureFlags,
     this.configOverrides,
   });
-
 
   @override
   String toString() {
@@ -69,4 +71,42 @@ class JitsiMeetingOptions {
       userAvatarUrl.hashCode ^
       const MapEquality().hash(featureFlags) ^
       const MapEquality().hash(configOverrides);
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'roomNameOrUrl': roomNameOrUrl,
+      'serverUrl': serverUrl,
+      'subject': subject,
+      'token': token,
+      'isAudioMuted': isAudioMuted,
+      'isAudioOnly': isAudioOnly,
+      'isVideoMuted': isVideoMuted,
+      'userDisplayName': userDisplayName,
+      'userEmail': userEmail,
+      'userAvatarUrl': userAvatarUrl,
+      'featureFlags': featureFlags,
+      'configOverrides': configOverrides,
+    };
+  }
+
+  factory JitsiMeetingOptions.fromMap(Map<String, dynamic> map) {
+    return JitsiMeetingOptions(
+      roomNameOrUrl: map['roomNameOrUrl'] as String,
+      serverUrl: map['serverUrl'] != null ? map['serverUrl'] as String : null,
+      subject: map['subject'] != null ? map['subject'] as String : null,
+      token: map['token'] != null ? map['token'] as String : null,
+      isAudioMuted: map['isAudioMuted'] != null ? map['isAudioMuted'] as bool : null,
+      isAudioOnly: map['isAudioOnly'] != null ? map['isAudioOnly'] as bool : null,
+      isVideoMuted: map['isVideoMuted'] != null ? map['isVideoMuted'] as bool : null,
+      userDisplayName: map['userDisplayName'] != null ? map['userDisplayName'] as String : null,
+      userEmail: map['userEmail'] != null ? map['userEmail'] as String : null,
+      userAvatarUrl: map['userAvatarUrl'] != null ? map['userAvatarUrl'] as String : null,
+      featureFlags: map['featureFlags'] != null ? Map<FeatureFlag, Object?>.from(map['featureFlags'] as Map<FeatureFlag, Object?>) : null,
+      configOverrides: map['configOverrides'] != null ? Map<String, Object?>.from(map['configOverrides'] as Map<String, Object?>) : null,
+    );
+  }
+
+  String toJson() => json.encode(toMap());
+
+  factory JitsiMeetingOptions.fromJson(String source) => JitsiMeetingOptions.fromMap(json.decode(source) as Map<String, dynamic>);
 }

--- a/jitsi_meet_wrapper_platform_interface/lib/method_channel_jitsi_meet_wrapper.dart
+++ b/jitsi_meet_wrapper_platform_interface/lib/method_channel_jitsi_meet_wrapper.dart
@@ -82,6 +82,16 @@ class MethodChannelJitsiMeetWrapper extends JitsiMeetWrapperPlatformInterface {
     });
   }
 
+  @override
+  Future<void> attachListener(    
+    JitsiMeetingListener listener,
+    ) async {
+    _listener = listener;
+    if (!_eventChannelIsInitialized) {
+      _initialize();
+    }
+  }
+
   void _initialize() {
     _eventChannel.receiveBroadcastStream().listen((message) {
       final data = message['data'];
@@ -236,6 +246,8 @@ class MethodChannelJitsiMeetWrapper extends JitsiMeetWrapperPlatformInterface {
         return 'video-mute.enabled';
       case FeatureFlag.isVideoShareButtonEnabled:
         return 'video-share.enabled';
+      case FeatureFlag.isPrejoinPageEnabled:
+        return 'prejoinpage.enabled';
     }
   }
 }


### PR DESCRIPTION
Hello!

This PR attempts to implement changes discussed in #36.
I took the changes proposed by @geiszla in https://github.com/BindrUK/jitsi_meet/tree/platform-view

In addition to iOS NativeView implementation this changes also contain:
- added a feature flag proposed in https://github.com/saibotma/jitsi_meet_wrapper/pull/67 as it was needed in my project,
- fromJson and toJson methods to JitsiMeetingOptions for ease of passing them through the methodChannels

I'm still working on the Android part as it's much more tricky than the iOS part. I tried to implement changes from the fork mentioned above but so far failed to get it working as ReactNative parts seem to be outdated.

I also tried to embed it directly but I was not able to do that with the need for wrapping the JitsiMeetView in JitsiMeetActivity.

Notice that I temporarily changed the pubspec.yaml to relative import of jitsi_meet_wrapper_platform_interface. As the changes are in both packages I left it for testing purposes. 

This is still work in progress, I will continue implementing the missing android part, but I'm looking forward for any feedback/suggestions/support as my android knowledge is quite limited.

Thank you