### PR TITLE
fix participantsInfoRetrieved event handler

### DIFF
--- a/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperEventStreamHandler.kt
+++ b/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperEventStreamHandler.kt
@@ -53,7 +53,7 @@ class JitsiMeetWrapperEventStreamHandler private constructor() : EventChannel.St
     }
 
     fun onParticipantsInfoRetrieved(data: MutableMap<String, Any>?) {
-        eventSink?.success(mapOf("event" to "participantInfoRetrieved", "data" to data))
+        eventSink?.success(mapOf("event" to "participantsInfoRetrieved", "data" to data))
     }
 
     fun onChatMessageReceived(data: MutableMap<String, Any>?) {

--- a/jitsi_meet_wrapper_platform_interface/lib/jitsi_meeting_listener.dart
+++ b/jitsi_meet_wrapper_platform_interface/lib/jitsi_meeting_listener.dart
@@ -45,7 +45,7 @@ class JitsiMeetingListener {
   // Only for Android
   // https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-android-sdk#participants_info_retrieved
   final Function(
-    Map<String, dynamic> participantsInfo,
+    String participantsInfo,
     String requestId,
   )? onParticipantsInfoRetrieved;
 


### PR DESCRIPTION
Currently, the client is unable to listen to the participantsInfoRetrieved event due to the typo, which I fixed inside this PR. Moreover, the return type for the participantsInfo argument should be String instead of Map. The retrieveParticipantsInfo method is still not implemented yet, but hopefully you can implement that particular method in the near future and merge my PR.

If there are any conflicts or errors regarding these fixes, I am open to a discussion.

Thank you.