### PR TITLE
Bump jitsi-meet-sdk to 10.2.1

### DIFF
--- a/jitsi_meet_wrapper/android/build.gradle
+++ b/jitsi_meet_wrapper/android/build.gradle
@@ -32,12 +32,19 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     // Required by jitsi
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 
     kotlinOptions {
@@ -58,5 +65,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // From: https://github.com/jitsi/jitsi-maven-repository/tree/master/releases/org/jitsi/react/jitsi-meet-sdk
     // Changelog: https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-MOBILE-SDKS.md
-    implementation ('org.jitsi.react:jitsi-meet-sdk:8.1.2') { transitive = true }
+    implementation ('org.jitsi.react:jitsi-meet-sdk:10.2.1') { transitive = true }
 }

--- a/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperActivity.kt
+++ b/jitsi_meet_wrapper/android/src/main/kotlin/dev/saibotma/jitsi_meet_wrapper/JitsiMeetWrapperActivity.kt
@@ -64,7 +64,7 @@ class JitsiMeetWrapperActivity : JitsiMeetActivity() {
                 BroadcastEvent.Type.CHAT_MESSAGE_RECEIVED -> eventStreamHandler.onChatMessageReceived(data)
                 BroadcastEvent.Type.CHAT_TOGGLED -> eventStreamHandler.onChatToggled(data)
                 BroadcastEvent.Type.VIDEO_MUTED_CHANGED -> eventStreamHandler.onVideoMutedChanged(data)
-                BroadcastEvent.Type.READY_TO_CLOSE -> {}
+                else -> {}
             }
         }
     }

--- a/jitsi_meet_wrapper/example/android/app/build.gradle
+++ b/jitsi_meet_wrapper/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -37,6 +37,17 @@ android {
         jvmTarget = '1.8'
     }
 
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86/libfbjni.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/x86_64/libfbjni.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libfbjni.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libfbjni.so'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -45,7 +56,7 @@ android {
         applicationId "dev.saibotma.jitsi_meet_wrapper_example"
         // Required by jitsi
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
* `compileSdkVersion` to `34`
* `targetSdkVersion` to `34`
* `org.jitsi.react:jitsi-meet-sdk` to `10.2.1`

Fixes:

```
Starting FGS with type mediaProjection callerApp=ProcessRecord{8212e7e 22282:com.landa.app/u0a274}
targetSDK=34
requires permissions: all of the permissions allOf=true
[android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION] any of the permissions allOf=false [android.permission.CAPTURE_VIDEO_OUTPUT, android:project_media]
```

Maybe #127 